### PR TITLE
Make moth less location dependent

### DIFF
--- a/moth
+++ b/moth
@@ -5,7 +5,9 @@ import subprocess, sys, os
 env = os.environ.copy()
 env["MOTH_HOME"] = "/".join(os.path.realpath(__file__).split("/")[:-1])
 
+script_dir = os.path.dirname(__file__)
+
 # Execute SOMns with the update environment
-os.system("./kernan/Grace/grace --ws > /dev/null 2>&1 &")
-os.execvpe("./SOMns/som", sys.argv, env)
+os.system(script_dir + "/kernan/Grace/grace --ws > /dev/null 2>&1 &")
+os.execvpe(script_dir + "/SOMns/som", sys.argv, env)
 os.system("(sh \"pkill -f kernan\" > /dev/null 2>&1)")


### PR DESCRIPTION
Note that `os.system("(sh \"pkill -f kernan\" > /dev/null 2>&1)")` is never actually executed.
`execvpe` does not return.
I am also not entirely sure what `env["MOTH_HOME"] = "/".join(os.path.realpath(__file__).split("/")[:-1])` is about, but it looks complex.